### PR TITLE
fix: broken build when renderModernChunks=false & polyfills=false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -266,7 +266,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
 
       // legacy bundle
-      if (legacyPolyfills.size) {
+      if (options.polyfills !== false) {
         // check if the target needs Promise polyfill because SystemJS relies on it
         // https://github.com/systemjs/systemjs#ie11-support
         await detectPolyfills(
@@ -274,7 +274,9 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           targets,
           legacyPolyfills,
         )
+      }
 
+      if (legacyPolyfills.size || !options.externalSystemJS) {
         if (isDebug) {
           console.log(
             `[vite-plugin-legacy-swc] legacy polyfills:`,


### PR DESCRIPTION
Hi again, this PR cherry-picks https://github.com/vitejs/vite/pull/14346. There's some more information about the bug in https://github.com/vitejs/vite/issues/14324. [This repository](https://github.com/k-yle/vite-legacy-broken-build) is a minimal reproduction for testing the bugfix. 