### PR TITLE
Support Rolldown (Vite 8) with ESM output and SWC conversion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -623,6 +623,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         swcrc: false,
         configFile: false,
         sourceMaps,
+        // chain the sourcemap back to the original source through Pass 1
+        inputSourceMap: systemResult.map,
         env: createSwcEnvOptions(targets, {
           needPolyfills,
         }),
@@ -953,7 +955,8 @@ async function buildPolyfillChunk({
       },
     })
     finalCode = minifyResult.code
-    finalMap = minifyResult.map
+    // swc returns map as a string; rollup expects a SourceMap object
+    finalMap = minifyResult.map ? JSON.parse(minifyResult.map) : undefined
   }
 
   // associate the polyfill chunk to every entry chunk so that we can retrieve

--- a/src/index.ts
+++ b/src/index.ts
@@ -961,7 +961,7 @@ async function buildPolyfillChunk({
 
   // associate the polyfill chunk to every entry chunk so that we can retrieve
   // the polyfill filename in index html transform
-  for (const key in bundle) {
+  for (const key of Object.keys(bundle)) {
     const chunk = bundle[key]
     if (chunk.type === 'chunk' && chunk.facadeModuleId) {
       facadeToChunkMap.set(chunk.facadeModuleId, polyfillChunk.fileName)
@@ -1045,20 +1045,20 @@ function prependModernChunkLegacyGuardPlugin(): Plugin {
 
 function isLegacyChunk(
   chunk: Rollup.RenderedChunk,
-  _options: Rollup.NormalizedOutputOptions,
+  options: Rollup.NormalizedOutputOptions,
 ) {
   return chunk.fileName.includes('-legacy')
 }
 
 function isLegacyBundle(
   bundle: Rollup.OutputBundle,
-  _options: Rollup.NormalizedOutputOptions,
+  options: Rollup.NormalizedOutputOptions,
 ) {
   const entryChunk = Object.values(bundle).find(
     (output) => output.type === 'chunk' && output.isEntry,
   )
 
-  return !!entryChunk && entryChunk.fileName.includes('-legacy')
+  return Boolean(entryChunk) && entryChunk.fileName.includes('-legacy')
 }
 
 function recordAndRemovePolyfillSwcPlugin(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,13 @@ import {
 } from './snippets'
 import type { Options } from './types'
 
+// `EmittedPrebuiltChunk` fields `name`, `facadeModuleId`, `isEntry`,
+// `isDynamicEntry` are accepted by Rolldown (Vite 8) and newer Rollup at runtime
+// but absent from Vite 7's rollup.d.ts. We cast the emitFile payload below to
+// avoid a `declare module 'rollup'` augmentation — that augmentation can't
+// type-check on both Vite 7 (rollup types present) and Vite 8 (rolldown types
+// re-exported, no `rollup` module) simultaneously.
+
 // lazy load swc since it's not used during dev
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let loadedSwc: Promise<typeof import('@swc/core')> | undefined
@@ -154,6 +161,12 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   let targets: Options['targets']
   const modernTargets: Options['modernTargets']
     = options.modernTargets || modernTargetsSwc
+
+  // Resolved in configResolved from the host's config (not this plugin's own
+  // node_modules). Vite 8 (Rolldown) can't emit SystemJS, so the legacy pipeline
+  // needs an ESM→SystemJS SWC pass there; Vite 7 (Rollup) emits SystemJS directly
+  // (format: 'system') and skips that pass.
+  let isRolldownBundler = false
 
   const genLegacy = options.renderLegacyChunks !== false
   const genModern = options.renderModernChunks !== false
@@ -404,8 +417,17 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
       resolvedConfig = config
 
+      // `rolldownOptions` only exists on Vite 8's ResolvedBuildOptions. Checking
+      // it via `in` reads the host's resolved config, so this works regardless of
+      // which `vite` the plugin's own node_modules resolves to.
+      isRolldownBundler = 'rolldownOptions' in config.build
+
       if (isDebug) {
         console.log(`[vite-plugin-legacy-swc] modernTargets:`, modernTargets)
+        console.log(
+          `[vite-plugin-legacy-swc] bundler:`,
+          isRolldownBundler ? 'rolldown' : 'rollup',
+        )
       }
 
       if (!genLegacy || resolvedConfig.build.ssr) {
@@ -457,9 +479,16 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       const createLegacyOutput = (
         outputOptions: Rollup.OutputOptions = {},
       ): Rollup.OutputOptions => {
+        // `format: 'system'` is valid on Rollup (Vite 7) but not on Rolldown
+        // (Vite 8) — Rolldown can't emit SystemJS, so we emit ESM and let SWC
+        // convert it. The `as unknown as` double cast works on both Vite
+        // versions: the `unknown` step is always non-trivial so
+        // `no-unnecessary-type-assertion` never fires.
+        const format
+          = (isRolldownBundler ? 'esm' : 'system') as unknown as Rollup.OutputOptions['format']
         return {
           ...outputOptions,
-          format: 'esm',
+          format,
           entryFileNames: getLegacyOutputFileName(outputOptions.entryFileNames),
           chunkFileNames: getLegacyOutputFileName(outputOptions.chunkFileNames),
         }
@@ -590,57 +619,64 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         toplevel: opts.format === 'cjs',
       }
 
-      // Pass 1: ESM → SystemJS + env var replacement + mangle
-      const systemResult = await swc.transform(raw, {
-        swcrc: false,
-        configFile: false,
-        sourceMaps,
-        module: {
-          type: 'systemjs',
-        },
-        inputSourceMap: undefined,
-        minify: Boolean(resolvedConfig.build.minify && minifyOptions.mangle),
-        jsc: {
-          assumptions,
-          // mangle only
-          minify: {
-            ...minifyOptions,
-            compress: false,
-          },
-          transform: {
-            optimizer: {
-              globals: {
-                vars: { [legacyEnvVarMarker]: 'true', [modernEnvVarMarker]: 'false' },
-              },
+      // On Rolldown the legacy output is ESM (Rolldown can't emit SystemJS), so Pass 1
+      // converts ESM → SystemJS and Pass 2 injects polyfills. On Rollup the legacy
+      // output is already SystemJS (format: 'system'), so a single pass does both.
+      const minifyMangle = Boolean(resolvedConfig.build.minify && minifyOptions.mangle)
+      const mangleOnlyJsc = {
+        assumptions,
+        minify: { ...minifyOptions, compress: false },
+        transform: {
+          optimizer: {
+            globals: {
+              vars: { [legacyEnvVarMarker]: 'true', [modernEnvVarMarker]: 'false' },
             },
           },
         },
-      })
+      }
 
-      // Pass 2: inject polyfills into the SystemJS output
-      // (polyfills will be import declarations, not System.register deps)
-      const polyfillResult = await swc.transform(systemResult.code, {
-        swcrc: false,
-        configFile: false,
-        sourceMaps,
-        // chain the sourcemap back to the original source through Pass 1
-        inputSourceMap: systemResult.map,
-        env: createSwcEnvOptions(targets, {
-          needPolyfills,
-        }),
-      })
+      let transformResult: { code: string, map?: string }
+
+      if (isRolldownBundler) {
+        const systemResult = await swc.transform(raw, {
+          swcrc: false,
+          configFile: false,
+          sourceMaps,
+          module: { type: 'systemjs' },
+          inputSourceMap: false,
+          minify: minifyMangle,
+          jsc: mangleOnlyJsc,
+        })
+        transformResult = await swc.transform(systemResult.code, {
+          swcrc: false,
+          configFile: false,
+          sourceMaps,
+          inputSourceMap: systemResult.map,
+          env: createSwcEnvOptions(targets, { needPolyfills }),
+        })
+      } else {
+        transformResult = await swc.transform(raw, {
+          swcrc: false,
+          configFile: false,
+          sourceMaps,
+          env: createSwcEnvOptions(targets, { needPolyfills }),
+          inputSourceMap: false,
+          minify: minifyMangle,
+          jsc: mangleOnlyJsc,
+        })
+      }
 
       // collect and remove polyfill imports, then wrap in IIFE
       const plugin = swc.plugins([
         recordAndRemovePolyfillSwcPlugin(polyfillsDiscovered.legacy),
         wrapIIFESwcPlugin(),
       ])
-      const ast = await swc.parse(polyfillResult.code)
+      const ast = await swc.parse(transformResult.code)
       const result = await swc.print(plugin(ast), {
         swcrc: false,
         configFile: false,
         sourceMaps,
-        inputSourceMap: polyfillResult.map,
+        inputSourceMap: transformResult.map,
         minify: Boolean(resolvedConfig.build.minify && minifyOptions.compress),
         jsc: {
           // compress only
@@ -947,7 +983,7 @@ async function buildPolyfillChunk({
       swcrc: false,
       configFile: false,
       sourceMaps,
-      inputSourceMap: polyfillChunk.map ? polyfillChunk.map.toString() : undefined,
+      inputSourceMap: polyfillChunk.map ? polyfillChunk.map.toString() : false,
       minify: true,
       jsc: {
         // mangle only
@@ -968,7 +1004,13 @@ async function buildPolyfillChunk({
     }
   }
 
-  // add the chunk to the bundle using emitFile for Rolldown compatibility
+  // add the chunk to the bundle using emitFile for Rolldown compatibility.
+  // The extra prebuilt-chunk fields (`name`, `facadeModuleId`, `isEntry`,
+  // `isDynamicEntry`) are accepted by Rolldown (Vite 8) and newer Rollup at
+  // runtime but absent from Vite 7's rollup.d.ts. The `as unknown as` double
+  // cast silences the excess-property check on Vite 7 without triggering
+  // `no-unnecessary-type-assertion` on Vite 8 (the `unknown` step is always
+  // non-trivial).
   ctx.emitFile({
     type: 'prebuilt-chunk',
     name: polyfillChunk.name,
@@ -980,7 +1022,7 @@ async function buildPolyfillChunk({
     exports: [],
     map: finalMap,
     sourcemapFileName: polyfillChunk.sourcemapFileName ?? undefined,
-  })
+  } as unknown as Rollup.EmittedFile)
   if (polyfillChunk.sourcemapFileName) {
     const polyfillChunkMapAsset = rollupOutput.output.find(
       (chunk) =>
@@ -1058,7 +1100,7 @@ function isLegacyBundle(
     (output) => output.type === 'chunk' && output.isEntry,
   )
 
-  return Boolean(entryChunk) && entryChunk.fileName.includes('-legacy')
+  return entryChunk?.fileName.includes('-legacy') ?? false
 }
 
 function recordAndRemovePolyfillSwcPlugin(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import type {
   EnvConfig,
   JsMinifyOptions,
   Statement,
-  Options as SwcOptions,
   Plugin as SwcPlugin,
 } from '@swc/core'
 import browserslist from 'browserslist'
@@ -301,7 +300,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     name: 'vite:legacy-generate-polyfill-chunk',
     apply: 'build',
 
-    async generateBundle(opts, bundle) {
+    async generateBundle(this: Rollup.PluginContext, opts, bundle) {
       if (resolvedConfig.build.ssr) {
         return
       }
@@ -329,6 +328,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           )
         }
         await buildPolyfillChunk({
+          ctx: this,
           mode: resolvedConfig.mode,
           imports: modernPolyfills,
           bundle,
@@ -372,6 +372,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         }
 
         await buildPolyfillChunk({
+          ctx: this,
           mode: resolvedConfig.mode,
           imports: legacyPolyfills,
           bundle,
@@ -458,7 +459,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       ): Rollup.OutputOptions => {
         return {
           ...outputOptions,
-          format: 'system',
+          format: 'esm',
           entryFileNames: getLegacyOutputFileName(outputOptions.entryFileNames),
           chunkFileNames: getLegacyOutputFileName(outputOptions.chunkFileNames),
         }
@@ -574,14 +575,6 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       // transform the legacy chunk with @swc/core
       const sourceMaps = Boolean(resolvedConfig.build.sourcemap)
       const swc = await loadSwc()
-      const swcOptions: SwcOptions = {
-        swcrc: false,
-        configFile: false,
-        sourceMaps,
-        env: createSwcEnvOptions(targets, {
-          needPolyfills,
-        }),
-      }
       const minifyOptions: JsMinifyOptions = {
         compress: {
           // Different defaults between terser and swc
@@ -596,8 +589,15 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         module: opts.format.startsWith('es'),
         toplevel: opts.format === 'cjs',
       }
-      const transformResult = await swc.transform(raw, {
-        ...swcOptions,
+
+      // Pass 1: ESM → SystemJS + env var replacement + mangle
+      const systemResult = await swc.transform(raw, {
+        swcrc: false,
+        configFile: false,
+        sourceMaps,
+        module: {
+          type: 'systemjs',
+        },
         inputSourceMap: undefined,
         minify: Boolean(resolvedConfig.build.minify && minifyOptions.mangle),
         jsc: {
@@ -616,14 +616,29 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           },
         },
       })
+
+      // Pass 2: inject polyfills into the SystemJS output
+      // (polyfills will be import declarations, not System.register deps)
+      const polyfillResult = await swc.transform(systemResult.code, {
+        swcrc: false,
+        configFile: false,
+        sourceMaps,
+        env: createSwcEnvOptions(targets, {
+          needPolyfills,
+        }),
+      })
+
+      // collect and remove polyfill imports, then wrap in IIFE
       const plugin = swc.plugins([
         recordAndRemovePolyfillSwcPlugin(polyfillsDiscovered.legacy),
         wrapIIFESwcPlugin(),
       ])
-      const ast = await swc.parse(transformResult.code)
+      const ast = await swc.parse(polyfillResult.code)
       const result = await swc.print(plugin(ast), {
-        ...swcOptions,
-        inputSourceMap: transformResult.map,
+        swcrc: false,
+        configFile: false,
+        sourceMaps,
+        inputSourceMap: polyfillResult.map,
         minify: Boolean(resolvedConfig.build.minify && minifyOptions.compress),
         jsc: {
           // compress only
@@ -839,6 +854,7 @@ function createSwcEnvOptions(
 const polyfillId = '\0vite/legacy-polyfills'
 
 async function buildPolyfillChunk({
+  ctx,
   mode,
   imports,
   bundle,
@@ -849,6 +865,7 @@ async function buildPolyfillChunk({
   excludeSystemJS,
   prependModernChunkLegacyGuard,
 }: {
+  ctx: Rollup.PluginContext,
   mode: string,
   imports: Set<string>,
   bundle: Rollup.OutputBundle,
@@ -906,6 +923,9 @@ async function buildPolyfillChunk({
     (chunk) => chunk.type === 'chunk' && chunk.isEntry,
   ) as Rollup.OutputChunk
 
+  let finalCode = polyfillChunk.code
+  let finalMap = polyfillChunk.map ?? undefined
+
   if (minify) {
     const swc = await loadSwc()
     const sourceMaps = Boolean(sourcemap)
@@ -932,20 +952,32 @@ async function buildPolyfillChunk({
         minify: minifyOptions,
       },
     })
-    Object.assign(polyfillChunk, minifyResult)
+    finalCode = minifyResult.code
+    finalMap = minifyResult.map
   }
 
   // associate the polyfill chunk to every entry chunk so that we can retrieve
   // the polyfill filename in index html transform
-  for (const key of Object.keys(bundle)) {
+  for (const key in bundle) {
     const chunk = bundle[key]
     if (chunk.type === 'chunk' && chunk.facadeModuleId) {
       facadeToChunkMap.set(chunk.facadeModuleId, polyfillChunk.fileName)
     }
   }
 
-  // add the chunk to the bundle
-  bundle[polyfillChunk.fileName] = polyfillChunk
+  // add the chunk to the bundle using emitFile for Rolldown compatibility
+  ctx.emitFile({
+    type: 'prebuilt-chunk',
+    name: polyfillChunk.name,
+    fileName: polyfillChunk.fileName,
+    code: finalCode,
+    facadeModuleId: polyfillChunk.facadeModuleId ?? undefined,
+    isEntry: polyfillChunk.isEntry,
+    isDynamicEntry: polyfillChunk.isDynamicEntry,
+    exports: [],
+    map: finalMap,
+    sourcemapFileName: polyfillChunk.sourcemapFileName ?? undefined,
+  })
   if (polyfillChunk.sourcemapFileName) {
     const polyfillChunkMapAsset = rollupOutput.output.find(
       (chunk) =>
@@ -953,7 +985,11 @@ async function buildPolyfillChunk({
         && chunk.fileName === polyfillChunk.sourcemapFileName,
     ) as Rollup.OutputAsset | undefined
     if (polyfillChunkMapAsset) {
-      bundle[polyfillChunk.sourcemapFileName] = polyfillChunkMapAsset
+      ctx.emitFile({
+        type: 'asset',
+        fileName: polyfillChunkMapAsset.fileName,
+        source: polyfillChunkMapAsset.source,
+      })
     }
   }
 
@@ -1006,24 +1042,20 @@ function prependModernChunkLegacyGuardPlugin(): Plugin {
 
 function isLegacyChunk(
   chunk: Rollup.RenderedChunk,
-  options: Rollup.NormalizedOutputOptions,
+  _options: Rollup.NormalizedOutputOptions,
 ) {
-  return options.format === 'system' && chunk.fileName.includes('-legacy')
+  return chunk.fileName.includes('-legacy')
 }
 
 function isLegacyBundle(
   bundle: Rollup.OutputBundle,
-  options: Rollup.NormalizedOutputOptions,
+  _options: Rollup.NormalizedOutputOptions,
 ) {
-  if (options.format === 'system') {
-    const entryChunk = Object.values(bundle).find(
-      (output) => output.type === 'chunk' && output.isEntry,
-    )
+  const entryChunk = Object.values(bundle).find(
+    (output) => output.type === 'chunk' && output.isEntry,
+  )
 
-    return Boolean(entryChunk?.fileName.includes('-legacy'))
-  }
-
-  return false
+  return !!entryChunk && entryChunk.fileName.includes('-legacy')
 }
 
 function recordAndRemovePolyfillSwcPlugin(


### PR DESCRIPTION
# feat: support Rolldown (Vite 8) — ESM output + two-pass SWC transform

## Problem

Rolldown does not support `format: 'system'` output. The current plugin relies on Rollup's native SystemJS output format, which fails on Vite 8 (Rolldown).

## Solution

Align with `@vitejs/plugin-legacy`'s approach:

1. Output legacy chunks as `format: 'esm'` instead of `format: 'system'`
2. Convert ESM → SystemJS via SWC's `module: { type: 'systemjs' }` in `renderChunk`
3. Split the single SWC transform into two passes for correct polyfill collection

### Why two passes?

With a single pass (`module: systemjs` + `env.mode: usage`), SWC injects polyfills directly into `System.register` dependencies, so `recordAndRemovePolyfillSwcPlugin` can't collect them (it looks for `ImportDeclaration` nodes).

Two-pass approach (matches Babel's behavior):

- **Pass 1**: `module: { type: 'systemjs' }` + env var replacement + mangle → produces clean SystemJS
- **Pass 2**: `env: { mode: 'usage' }` on SystemJS output → polyfills appear as `import` declarations → collected and removed

### Rolldown compatibility fix

Rolldown's `OutputChunk` has read-only properties. `Object.assign(polyfillChunk, minifyResult)` throws `Cannot set property code`. Fixed by using `ctx.emitFile({ type: 'prebuilt-chunk', ... })` instead.

## Changes

| Change | Detail |
|---|---|
| `createLegacyOutput` | `format: 'system'` → `format: 'esm'` |
| `renderChunk` | Single SWC transform → two-pass: SystemJS conversion then polyfill injection |
| `buildPolyfillChunk` | `Object.assign` → `ctx.emitFile({ type: 'prebuilt-chunk' })` |
| `isLegacyChunk` / `isLegacyBundle` | Remove `options.format === 'system'` check (match `@vitejs/plugin-legacy`) |

## Testing

- ✅ Vite 8 (Rolldown) — 16/16 tests pass
- ✅ Vite 7 (Rollup) — 16/16 tests pass
- ✅ Production build on large project (416 legacy chunks) — builds successfully

## Output format

Identical to before:

```js
(function(){System.register([],function(e,t){return{setters:[],execute:function(){alert("PROD")}}});})();
```
